### PR TITLE
mappings to silent

### DIFF
--- a/plugin/simple-todo.vim
+++ b/plugin/simple-todo.vim
@@ -54,18 +54,18 @@ inore <Plug>(simple-todo-mark-as-undone) <Esc>:s/^\(\s*[-+*]\?\s*\)\[x\]/\1[ ]/<
 " Key bindings {{{
 
 if g:simple_todo_map_keys
-  nmap <Leader>i <Plug>(simple-todo-new)
-  imap <Leader>i <Plug>(simple-todo-new)
-  nmap <Leader>o <Plug>(simple-todo-below)
-  imap <Leader>o <Plug>(simple-todo-below)
-  nmap <Leader>O <Plug>(simple-todo-above)
-  imap <Leader>O <Plug>(simple-todo-above)
-  nmap <Leader>x <Plug>(simple-todo-mark-as-done)
-  vmap <Leader>x <Plug>(simple-todo-mark-as-done)
-  imap <Leader>x <Plug>(simple-todo-mark-as-done)
-  nmap <Leader>X <Plug>(simple-todo-mark-as-undone)
-  vmap <Leader>X <Plug>(simple-todo-mark-as-undone)
-  imap <Leader>X <Plug>(simple-todo-mark-as-undone)
+  nmap <silent><Leader>i <Plug>(simple-todo-new)
+  imap <silent><Leader>i <Plug>(simple-todo-new)
+  nmap <silent><Leader>o <Plug>(simple-todo-below)
+  imap <silent><Leader>o <Plug>(simple-todo-below)
+  nmap <silent><Leader>O <Plug>(simple-todo-above)
+  imap <silent><Leader>O <Plug>(simple-todo-above)
+  nmap <silent><Leader>x <Plug>(simple-todo-mark-as-done)
+  vmap <silent><Leader>x <Plug>(simple-todo-mark-as-done)
+  imap <silent><Leader>x <Plug>(simple-todo-mark-as-done)
+  nmap <silent><Leader>X <Plug>(simple-todo-mark-as-undone)
+  vmap <silent><Leader>X <Plug>(simple-todo-mark-as-undone)
+  imap <silent><Leader>X <Plug>(simple-todo-mark-as-undone)
 endif
 
 " }}}


### PR DESCRIPTION
In default of this plugin, mapping is verbose. 
For example, when we enter `<leader>x`, command is showed in statusbar.

This PR is only not for showing commands in statusbar.