### PR TITLE
Optional insert mode keys

### DIFF
--- a/doc/simple-todo.txt
+++ b/doc/simple-todo.txt
@@ -27,8 +27,8 @@ https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments
 ==============================================================================
 2. Mappings                                                 *simple-todo-maps*
 
-Plugin exposes some <Plug> maps. These maps are available for normal and
-insert modes.
+Plugin exposes some <Plug> maps. These maps are available for normal, visual
+and insert modes.
 
 To completely disable default key bindings (which is pretty handy) use:
 >
@@ -37,6 +37,10 @@ let g:simple_todo_map_keys = 0
                                                      *<Plug>(simple-todo-new)*
 <Plug>(simple-todo-new)
 <leader>i                   Create a new item
+
+                                       *<Plug>(simple-todo-new-start-of-line)*
+<Plug>(simple-todo-new-start-of-line)
+<leader>I                   Create a new item at the start of this line
 
                                                    *<Plug>(simple-todo-below)*
 <Plug>(simple-todo-below)

--- a/doc/simple-todo.txt
+++ b/doc/simple-todo.txt
@@ -33,6 +33,13 @@ and insert modes.
 To completely disable default key bindings (which is pretty handy) use:
 >
 let g:simple_todo_map_keys = 0
+
+By default, simple-todo adds mappings for Insert mode. Since the mappings
+start with <Leader> this will cause a slight lag when the <Leader> key (e.g.
+'/' or ',') is pressed. To disable default mappings in Insert mode:
+
+let g:simple_todo_map_insert_mode_keys = 0
+
 <
                                                      *<Plug>(simple-todo-new)*
 <Plug>(simple-todo-new)

--- a/plugin/simple-todo.vim
+++ b/plugin/simple-todo.vim
@@ -32,6 +32,11 @@ endfu " }}}
 nnore <Plug>(simple-todo-new) a[ ]<space>
 inore <Plug>(simple-todo-new) [ ]<space>
 
+" Create a new item at the start of this line
+inore <Plug>(simple-todo-new-start-of-line) <Esc>mzI[ ]<space><Esc>`z4la
+nnore <Plug>(simple-todo-new-start-of-line) mzI[ ]<space><Esc>`z4l
+vnore <Plug>(simple-todo-new-start-of-line) I[ ]<space>
+
 " Create a new item below
 nnore <Plug>(simple-todo-below) o<c-r>=<SID>get_list_marker(line('.')-1)<cr>[ ]<space>
 inore <Plug>(simple-todo-below) <Esc>o<c-r>=<SID>get_list_marker(line('.')-1)<cr>[ ]<space>
@@ -56,6 +61,9 @@ inore <Plug>(simple-todo-mark-as-undone) <Esc>:s/^\(\s*[-+*]\?\s*\)\[x\]/\1[ ]/<
 if g:simple_todo_map_keys
   nmap <Leader>i <Plug>(simple-todo-new)
   imap <Leader>i <Plug>(simple-todo-new)
+  imap <Leader>I <Plug>(simple-todo-new-start-of-line)
+  nmap <Leader>I <Plug>(simple-todo-new-start-of-line)
+  vmap <Leader>I <Plug>(simple-todo-new-start-of-line)
   nmap <Leader>o <Plug>(simple-todo-below)
   imap <Leader>o <Plug>(simple-todo-below)
   nmap <Leader>O <Plug>(simple-todo-above)

--- a/plugin/simple-todo.vim
+++ b/plugin/simple-todo.vim
@@ -18,6 +18,11 @@ if !exists('g:simple_todo_map_keys')
   let g:simple_todo_map_keys = 1
 endif
 
+" Do map insert mode bindings (yes)
+if !exists('g:simple_todo_map_insert_mode_keys')
+  let g:simple_todo_map_insert_mode_keys = 1
+endif
+
 " }}}
 " Private functions {{{
 
@@ -60,19 +65,22 @@ inore <Plug>(simple-todo-mark-as-undone) <Esc>:s/^\(\s*[-+*]\?\s*\)\[x\]/\1[ ]/<
 
 if g:simple_todo_map_keys
   nmap <silent><Leader>i <Plug>(simple-todo-new)
-  imap <silent><Leader>i <Plug>(simple-todo-new)
-  imap <silent><Leader>I <Plug>(simple-todo-new-start-of-line)
   nmap <silent><Leader>I <Plug>(simple-todo-new-start-of-line)
   vmap <silent><Leader>I <Plug>(simple-todo-new-start-of-line)
   nmap <silent><Leader>o <Plug>(simple-todo-below)
-  imap <silent><Leader>o <Plug>(simple-todo-below)
   nmap <silent><Leader>O <Plug>(simple-todo-above)
-  imap <silent><Leader>O <Plug>(simple-todo-above)
   nmap <silent><Leader>x <Plug>(simple-todo-mark-as-done)
   vmap <silent><Leader>x <Plug>(simple-todo-mark-as-done)
-  imap <silent><Leader>x <Plug>(simple-todo-mark-as-done)
   nmap <silent><Leader>X <Plug>(simple-todo-mark-as-undone)
   vmap <silent><Leader>X <Plug>(simple-todo-mark-as-undone)
+endif
+
+if g:simple_todo_map_insert_mode_keys
+  imap <silent><Leader>i <Plug>(simple-todo-new)
+  imap <silent><Leader>I <Plug>(simple-todo-new-start-of-line)
+  imap <silent><Leader>o <Plug>(simple-todo-below)
+  imap <silent><Leader>O <Plug>(simple-todo-above)
+  imap <silent><Leader>x <Plug>(simple-todo-mark-as-done)
   imap <silent><Leader>X <Plug>(simple-todo-mark-as-undone)
 endif
 


### PR DESCRIPTION
Insert mode mapping with `<Leader>` can be annoying, because they create a lag whenever `<Leader>` is pressed and fire when they weren't meant to fire (e.g. editing CSV).